### PR TITLE
Feature/flexible load names

### DIFF
--- a/LoadInfo.xaml.cs
+++ b/LoadInfo.xaml.cs
@@ -35,6 +35,10 @@ namespace LoadRetimer {
             isInclusive = true;
         }
 
+        public void Rename(String newName) {
+            SetName(newName);
+        }
+
         public void SetBegin(TimeSpan begin) {
             frameStart = (long) Math.Round(begin.TotalSeconds * MainWindow.frameRate);
             TryCalculate();

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -65,7 +65,7 @@
         <ListBox Grid.Row="2" Grid.Column="2" x:Name="LoadBox" HorizontalContentAlignment="Stretch" />
         <ComboBox x:Name="LoadCategory" Grid.Row="3" Grid.Column="2" SelectionChanged="ComboBox_SelectionChanged">
             <ComboBoxItem IsSelected="True">NSMBW Any%</ComboBoxItem>
-            <ComboBoxItem>Other</ComboBoxItem>
+            <ComboBoxItem>Generic/Extra Loads</ComboBoxItem>
         </ComboBox>
         <Grid Grid.Row="4" Grid.Column="0" Grid.ColumnSpan="2">
             <Grid.ColumnDefinitions>

--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -24,6 +24,7 @@
         <Menu Grid.Row="0" Grid.ColumnSpan="3">
             <MenuItem Header="_File">
                 <MenuItem Header="_Open Video" Click="OpenFile_Click" />
+                <MenuItem Header="_Open Load Names" Click="OpenLoadNames_Click" />
                 <MenuItem Header="_Open Loads" Click="OpenLoads_Click" />
                 <MenuItem Header="_Save Loads" Click="SaveLoads_Click" />
                 <MenuItem Header="_Info" Click="Info_Click" />

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -99,6 +99,12 @@ namespace LoadRetimer {
             };
             timerAnalyzer.Tick += Analyzer_Tick;
             timerAnalyzer.Start();
+
+            if (File.Exists("defaultNames.lns")) {
+                LoadCustomNames("defaultNames.lns");
+            } else {
+                customLoadNames = anyPercentLoadNames.ToList<string>();
+            }
         }
 
         private void LoadCustomNames(string filename) {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Forms;
@@ -18,6 +20,8 @@ namespace LoadRetimer {
         private DispatcherTimer timerAnalyzer;
 
         int loadType = 0;
+
+        List<string> customLoadNames;
 
         readonly string[] anyPercentLoadNames = new string[] {
             "1-1 Start",
@@ -97,6 +101,22 @@ namespace LoadRetimer {
             timerAnalyzer.Start();
         }
 
+        private void LoadCustomNames(string filename) {
+            customLoadNames = new List<string>();
+            foreach (string line in File.ReadLines(filename)) {
+                customLoadNames.Add(line);
+            }
+            for (int i = 0; i < LoadBox.Items.Count; i++) {
+                String newName;
+                if (i < customLoadNames.Count) {
+                    newName = customLoadNames[i];
+                } else {
+                    newName = String.Format("Load {0}", i + 1);
+                }
+                ((LoadInfo)((ListBoxItem)LoadBox.Items[i]).Content).Rename(newName);
+            }
+        }
+
         private void ButtonPlayPause_Click(object sender, RoutedEventArgs e) {
             if (!Video.IsOpen) return;
             if (Video.MediaState == Unosquare.FFME.Common.MediaPlaybackState.Play) {
@@ -130,8 +150,8 @@ namespace LoadRetimer {
             ListBoxItem lbi = new ListBoxItem();
             LoadInfo newLoad = new LoadInfo(String.Format("Load {0}", LoadBox.Items.Count + 1));
             if (loadType == 0) {
-                if (LoadBox.Items.Count < anyPercentLoadNames.Length) {
-                    newLoad.SetName(anyPercentLoadNames[LoadBox.Items.Count]);
+                if (LoadBox.Items.Count < customLoadNames.Count) {
+                    newLoad.SetName(customLoadNames[LoadBox.Items.Count]);
                 }
             }
             lbi.Content = newLoad;
@@ -195,6 +215,15 @@ namespace LoadRetimer {
         }
 
         const byte CURR_VERSION = 3;
+
+        private void OpenLoadNames_Click(object sender, RoutedEventArgs e) {
+            var ofd = new OpenFileDialog {
+                Title = "Select load names",
+                Filter = "Load Retimer Name files (*.lns)|*.lns|All files (*.*)|*.*"
+            };
+            if (ofd.ShowDialog() != System.Windows.Forms.DialogResult.OK) return;
+            LoadCustomNames(ofd.FileName);
+        }
 
         private void OpenLoads_Click(object sender, RoutedEventArgs e) {
             var ofd = new OpenFileDialog {

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -112,6 +112,9 @@ namespace LoadRetimer {
             foreach (string line in File.ReadLines(filename)) {
                 customLoadNames.Add(line);
             }
+            string categoryName = customLoadNames[0];
+            ((ComboBoxItem)LoadCategory.Items[0]).Content = categoryName;
+            customLoadNames.RemoveAt(0);
             for (int i = 0; i < LoadBox.Items.Count; i++) {
                 String newName;
                 if (i < customLoadNames.Count) {


### PR DESCRIPTION
- Custom load names files (.lns) can now be loaded to customize category and load names
- A default file can be read when the program starts, if it's present (defaultNames.lns)
  - If no default file is found, it falls back to the default hardcoded NSMB Wii Any% names
- Renamed "Other" category in the dropdown to make its new use case clearer
  - That is, if one wants to use generic names or insert extra loads not specified in the preset